### PR TITLE
mesh2ply should be able to write to a connection

### DIFF
--- a/R/mesh2ply.r
+++ b/R/mesh2ply.r
@@ -50,7 +50,10 @@ mesh2ply <- function(x, filename=dataname, col=NULL, writeNormals=FALSE)
     if (!is.null(x$ib))
         x <- quad2trimesh(x)
     
-    filename <- paste(filename,".ply",sep="")
+		if (is.character(filename)) {
+	    filename <- paste(filename,".ply",sep="")
+		}
+
     vert <- x$vb[1:3,]
     vert <- round(vert,digits=6)
     if (!is.null(x$it)) {


### PR DESCRIPTION
First of all thanks for implementing the mesh2ply() function - it's exactly what I was searching for!

Unfortunately the line 

```
filename <- paste(filename, ".ply", sep = "")
```

prevents it from being able to write directly to an R connection. I would like to have this feature and tried to come up with a simple solution that doesn't influence the initial functionality. 