### PR TITLE
Fix displacement vectors

### DIFF
--- a/R/meshDist.r
+++ b/R/meshDist.r
@@ -364,7 +364,7 @@ render.meshDist <- function(x,from=NULL,to=NULL,steps=NULL,ceiling=NULL,uprange=
         dismesh$vb <- cbind(colMesh$vb,rbind(clost,1))
         dismesh$it <- rbind(1:vl,1:vl,(1:vl)+vl)
         dismesh$material$color <- colorall
-        dismesh$normals <- cbind(dismesh2$normals, colMesh$normals)
+        dismesh$normals <- cbind(dismesh$normals, colMesh$normals)
         wire3d(dismesh,lit=FALSE)
     }
     diffo <- ((colramp[[2]][2]-colramp[[2]][1])/2)

--- a/R/meshDist.r
+++ b/R/meshDist.r
@@ -364,6 +364,7 @@ render.meshDist <- function(x,from=NULL,to=NULL,steps=NULL,ceiling=NULL,uprange=
         dismesh$vb <- cbind(colMesh$vb,rbind(clost,1))
         dismesh$it <- rbind(1:vl,1:vl,(1:vl)+vl)
         dismesh$material$color <- colorall
+        dismesh$normals <- cbind(dismesh2$normals, colMesh$normals)
         wire3d(dismesh,lit=FALSE)
     }
     diffo <- ((colramp[[2]][2]-colramp[[2]][1])/2)

--- a/R/meshDist.r
+++ b/R/meshDist.r
@@ -364,7 +364,7 @@ render.meshDist <- function(x,from=NULL,to=NULL,steps=NULL,ceiling=NULL,uprange=
         dismesh$vb <- cbind(colMesh$vb,rbind(clost,1))
         dismesh$it <- rbind(1:vl,1:vl,(1:vl)+vl)
         dismesh$material$color <- colorall
-        dismesh$normals <- cbind(dismesh$normals, colMesh$normals)
+        dismesh$normals <- cbind(dismesh$normals, dismesh$normals)
         wire3d(dismesh,lit=FALSE)
     }
     diffo <- ((colramp[[2]][2]-colramp[[2]][1])/2)


### PR DESCRIPTION
Had a look at the code for the displacement vectors and the final call to wire3d in the render method no longer likes that you didn't duplicate the normals when you duplicated the dimensions of rest of the mesh. It seems to come from a change in wire3d and not Morpho, but this fix addresses issue #27 . 

```R
data(nose)##load data
##warp a mesh onto another landmark configuration:
longnose.mesh <- tps3d(shortnose.mesh, shortnose.lm, longnose.lm,threads=1)
## Not run: 
mD <- meshDist(longnose.mesh, shortnose.mesh, displace = T)
bg3d(1)
render(mD,rampcolors = c("white","red"), displace = T, alpha = 0)
```
<img width="897" alt="meshdist_ex" src="https://user-images.githubusercontent.com/9093863/136087575-a0393665-aa9d-4c2b-aa15-afb952dee7c0.PNG">


