### PR TITLE
replace long (deprecated) with length

### DIFF
--- a/R/plot.normals.r
+++ b/R/plot.normals.r
@@ -16,7 +16,7 @@
 #' \dontrun{
 #' require(rgl)
 #' data(nose)
-#' plotNormals(shortnose.mesh,col=4,long=0.01)
+#' plotNormals(shortnose.mesh,col=4,length=0.01)
 #' shade3d(shortnose.mesh,col=3)
 #' }
 #' 

--- a/man/plotNormals.Rd
+++ b/man/plotNormals.Rd
@@ -26,7 +26,7 @@ If no normals are contained, they are computed.
 \dontrun{
 require(rgl)
 data(nose)
-plotNormals(shortnose.mesh,col=4,long=0.01)
+plotNormals(shortnose.mesh,col=4,length=0.01)
 shade3d(shortnose.mesh,col=3)
 }
 


### PR DESCRIPTION
Replaced `long` with `length` in `plotNormals` (roxygen and man)