### PR TITLE
Make sf package optional

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ Suggests:
     car,
     lattice,
     shapes,
+    sf,
     testthat
 Depends:
     R (>= 3.2.0)
@@ -35,7 +36,6 @@ Imports:
     stats,
     utils,
     jsonlite,
-    sf,
     bezier
 LinkingTo: Rcpp, RcppArmadillo (>= 0.4)
 Copyright: see COPYRIGHTS file for details

--- a/R/computeArea.r
+++ b/R/computeArea.r
@@ -38,7 +38,9 @@ computeArea <- function(x) {
         xpro <- x
 ### setup data to be evaluated by rgeos
 
-   
+    if (!requireNamespace("sf", quietly = TRUE))
+        stop("Please install suggested package: ", "sf")
+      
     poly <- sf::st_polygon(list(rbind(xpro,xpro[1,])))
     area <- sf::st_area(poly)
     


### PR DESCRIPTION
Hi @zarquon42b, I haven't been in touch for a while but hope you are well. We're still happy users of your packages including Morpho and Rvcg. I was wondering if you would consider this PR to make the sf package an optional dependency (Suggests) rather than a hard dependency (Imports) of Morpho. The reason I would like to do this is that I find many linux systems do not have the `libudunits2-dev` library preinstalled. This then requires either sudo for package manager install or compiling and installing the library from scratch. Since `sf` is only used in one function, it seems reasonable to make its use conditional avoiding that hard dependency. Many thanks, Greg.