### PR TITLE
Icpmat prevent shrinking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,4 +45,4 @@ BugReports: https://github.com/zarquon42b/Morpho/issues
 LazyLoad: yes
 URL: https://github.com/zarquon42b/Morpho
 Encoding: UTF-8
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/Morpho.Rproj
+++ b/Morpho.Rproj
@@ -1,0 +1,18 @@
+Version: 1.0
+ProjectId: cbb7454b-23f6-4964-9516-b76f6802cd44
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/R/icpmat.r
+++ b/R/icpmat.r
@@ -11,6 +11,8 @@
 #' @param weights vector of length \code{nrow(x)} containing weights for each row in \code{x}
 #' @param centerweight logical: if weights are defined and centerweigths=TRUE, the matrix will be centered according to these weights instead of the barycenter.
 #' @param threads integer: number of threads to use.
+#' @param minscale double: for types "similarity" and "affine", minimum scale factor per iteration, prevents excessive shrinking in first iteration.
+#' @param mincumscale double: for types "similarity" and "affine", minimum cumulative scale factor, prevents shrinking below threshold (e.g. 0.7), values above 1 will enforce size increase, should only be used if both landmark configurations are in the same scale.
 #' @return returns the rotated landmarks
 #' @examples
 #' data(nose)
@@ -51,7 +53,7 @@
 #' }
 #' @importFrom Rvcg vcgKDtree vcgSearchKDtree vcgCreateKDtree
 #' @export
-icpmat <- function(x,y,iterations,mindist=1e15,subsample=NULL,type=c("rigid","similarity","affine"),weights=NULL,threads=1,centerweight=FALSE) {
+icpmat <- function(x,y,iterations,mindist=1e15,subsample=NULL,type=c("rigid","similarity","affine"),weights=NULL,threads=1,centerweight=FALSE,minscale=0.9, mincumscale=NULL) {
     m <- ncol(x)
     if (m == 2) {
         x <- cbind(x,0)
@@ -78,6 +80,28 @@ icpmat <- function(x,y,iterations,mindist=1e15,subsample=NULL,type=c("rigid","si
         if (!is.null(weights))
             tmpweights <- weights[good]
         trafo <- computeTransform(y[clost$index[good],],xtmp[good,],type=type,weights = tmpweights,centerweight = centerweight)
+        if(type!="rigid"){
+          # calculate scale factor from transformation matrix
+          scalef <- sqrt(sum(trafo[1:3,1]^2))
+          if (scalef<minscale){
+            trafo <- computeTransform(y[clost$index[good], ], xtmp[good, 
+            ], type = "rigid", weights = tmpweights, centerweight = centerweight)
+            scalef <- 1
+          }
+          cumscalef <- cumscalef * scalef
+          if(!is.null(mincumscale)){
+            if(cumscalef<mincumscale){
+              type <- "rigid"
+              warning("Cumulative scale factor belows mincumscalf, switching to rigid type")
+              #scale up by inverse of cumscalef
+              trafo <- matrix(0, 4, 4) 
+              trafo[1,1] <- 1/cumscalef
+              trafo[2,2] <- 1/cumscalef
+              trafo[3,3] <- 1/cumscalef
+              cumscalef <- 1 # reset cumscalef
+            }
+          }
+        }
         xtmp <- applyTransform(xtmp[,],trafo)
     }
     if (!is.null(subsample)) {

--- a/man/Morpho-package.Rd
+++ b/man/Morpho-package.Rd
@@ -33,6 +33,14 @@ population differences and sexual dimorphism. PhD thesis,
 \enc{Universitätsbibliothek}{Universitaetsbibliothek} Freiburg. URL:
 \url{http://www.freidok.uni-freiburg.de/volltexte/9181/}.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/zarquon42b/Morpho}
+  \item Report bugs at \url{https://github.com/zarquon42b/Morpho/issues}
+}
+
+}
 \author{
 Stefan Schlager \email{zarquon42@gmail.com}
 

--- a/man/icpmat.Rd
+++ b/man/icpmat.Rd
@@ -13,7 +13,9 @@ icpmat(
   type = c("rigid", "similarity", "affine"),
   weights = NULL,
   threads = 1,
-  centerweight = FALSE
+  centerweight = FALSE,
+  minscale = 0.9,
+  mincumscale = NULL
 )
 }
 \arguments{
@@ -25,7 +27,7 @@ icpmat(
 
 \item{mindist}{restrict valid points to be within this distance}
 
-\item{subsample}{use a subsample determined by kmean clusters to speed up computation}
+\item{subsample}{use only a subsample of points to speed up computation, if subsampling is desired specify parameter k for k-means clustering (number of subsampled points)}
 
 \item{type}{character: select the transform to be applied, can be "rigid","similarity" or "affine"}
 
@@ -34,6 +36,10 @@ icpmat(
 \item{threads}{integer: number of threads to use.}
 
 \item{centerweight}{logical: if weights are defined and centerweigths=TRUE, the matrix will be centered according to these weights instead of the barycenter.}
+
+\item{minscale}{double: for types "similarity" and "affine", minimum scale factor per iteration, prevents excessive shrinking in first iteration.}
+
+\item{mincumscale}{double: for types "similarity" and "affine", minimum cumulative scale factor, prevents shrinking below threshold (e.g. 0.7), values above 1 will enforce size increase, should only be used if both landmark configurations are in the same scale.}
 }
 \value{
 returns the rotated landmarks


### PR DESCRIPTION
So, I hope I did not make too many beginner mistakes this time. I am sorry for the inconvenience. This is the first time that I contribute to an R package, where the documentation had to be rebuilt. I forked Morpho, created a new branch for this pull request, edited the function file and built the documentation using `document()`. 

The minscale default value is of course very arbitrary. I am not sure how many iterations are typically used (there is no default value for it). If only very few iterations are used, this value might be too high.